### PR TITLE
fix: resolve 404 error on clicking the logo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,7 @@ theme:
 repo_url: https://github.com/matrixone-cloud/moc-docs
 edit_uri: edit/main/docs/
 extra:
-  homepage: https://www.matrixorigin.cn/MatrixOneCloud
+  homepage: https://www.matrixorigin.cn/matrixonecloud
   version:
     provider: mike
 extra_css:


### PR DESCRIPTION
点击左上角 MO logo 后，正确跳转至官网 MOC 页