### PR TITLE
fix golong bug caused by ':' in MOC-username

### DIFF
--- a/docs/MatrixOne-Cloud/App-Develop/Tutorial/develop-golang-crud-demo.md
+++ b/docs/MatrixOne-Cloud/App-Develop/Tutorial/develop-golang-crud-demo.md
@@ -2,26 +2,42 @@
 
 ## 配置环境
 
-- 已完成[创建实例](../../Instance-Mgmt/create-instance.md)。
-- 确认你已完成安装 [Golang 1.18 版本及以上](https://go.dev/dl/)，可以使用下面的命令行确认你的 Golang 版本：
 
-    ```
-    #To check with Golang installation and its version
-    go version
-    ```
+在你开始之前，确认你已经下载并安装了如下软件：
 
-- 确认你已完成安装 MySQL 客户端。
-- 下载并安装 [`Go-MySQL-Driver`](https://github.com/go-sql-driver/mysql) 工具。
+* 确认你已完成安装 MySQL 客户端。
+
+* 已完成[创建实例](../../Instance-Mgmt/create-instance.md)，并通过 MySQL 客户端连接 MatrixOne Cloud 并创建一个命名为 *test* 的数据库：
+
+    ```sql
+    mysql> create database test;
+    ```
+  
+* 确认你已完成安装 [Golang 1.18 版本及以上](https://go.dev/dl/)，可以使用下面的命令行确认你的 Golang 版本：
+
+	```
+	#To check with Golang installation and its version
+	go version
+	```
+
+* 确认你已经安装 `gorm.io/driver/mysql`，使用 `go get` 命令安装，代码如下：
+
+	```
+	go get -u gorm.io/driver/mysql
+	```
+
+
+你可以参考 [Golang 连接 MatrixOne Cloud 服务](../connect-mo/connect-to-matrixone-with-go.md)了解如何通过 `Golang` 连接到 MatrixOne Cloud，本篇文档将指导你如何实现 CRUD（创建、读取、更新、删除）。
 
 ## 步骤
 
-1. 通过 MySQL 客户端连接到 MatrixOne。创建一个名为 *test* 的新数据库。
+1. 通过 MySQL 客户端连接到 MatrixOne Cloud。创建一个名为 *test* 的新数据库。
 
     ```
     mysql> create database test;
     ```
 
-2. 创建一个命名为 `golang_crud_matrixone.go` 的纯文本文件，将下面的代码拷贝至文件内：
+2. 创建一个命名为 `golang_crud_matrixonecloud.go` 的纯文本文件，将下面的代码拷贝至文件内：
 
     ```python
     package main
@@ -34,8 +50,15 @@
     )
 
     func main() {
-       //Open a new connection to MatrixOne
-        db, err := sql.Open("mysql", "root:111@tcp(127.0.0.1:6001)/test")
+       //Open a new connection to MatrixOne Cloud
+        username := "tenant:user:role"  // modify this
+        host := "host_ip_address"       // modify this
+        password := "your_password"     // modify this
+        port := 6001
+        database := "test"              
+        encodedUsername := url.QueryEscape(username)
+        dbConnectionString := encodedUsername + ":" + password + "@tcp(" + host + ":" + strconv.Itoa(port) + ")/" + database
+        db, err := sql.Open("mysql", dbConnectionString)
         checkErr(err)
 
         //Create a table
@@ -112,7 +135,7 @@
 3. 打开一个新的终端，使用如下命令行，执行此 Golang 文件。
 
     ```
-    > go run golang_crud_matrixone.go
+    > go run golang_crud_matrixonecloud.go
     Successfully Created
     1
     1

--- a/docs/MatrixOne-Cloud/App-Develop/connect-mo/connect-to-matrixone-with-go.md
+++ b/docs/MatrixOne-Cloud/App-Develop/connect-mo/connect-to-matrixone-with-go.md
@@ -1,27 +1,28 @@
 # 使用 Golang 连接
 
-MatrixOne 支持 Golang 连接，并且支持 [`Go-MySQL-Driver`](https://github.com/go-sql-driver/mysql)。
+MatrixOne Cloud 支持 Golang 连接，并且支持 [Go-MySQL-Driver](https://github.com/go-sql-driver/mysql)。
 
-本篇文档将指导你了解如何使用 Golang 连接 MatrixOne。
+本篇文档将指导你了解如何使用 `Golang` 以及 `Gorm` 连接 MatrixOne Cloud 。
 
 ## 开始前准备
+
+
+- 已安装 [MySQL 客户端](https://dev.mysql.com/downloads/mysql)，如果你没有安装，可以点击 [MySQL 客户端](https://dev.mysql.com/downloads/mysql)至官方网站进行下载安装。
 
 - 已完成[创建实例](../../Instance-Mgmt/create-instance.md)。
 
 - 已安装 [Golang 1.18 版本及以上](https://go.dev/dl/)，如果你没有安装，可以点击 [Golang 1.18 版本及以上](https://go.dev/dl/)至官方网站进行下载安装；如果你已安装，可以使用下面的命令行检查版本：
 
-```
-#检查 Golang 版本号，确认是否安装
-go version
-```
-
-- 已安装 [MySQL 客户端](https://dev.mysql.com/downloads/mysql)，如果你没有安装，可以点击 [MySQL 客户端](https://dev.mysql.com/downloads/mysql)至官方网站进行下载安装。
+    ```
+    #检查 Golang 版本号，确认是否安装
+    go version
+    ```
 
 - 已安装 [Git](https://git-scm.com/downloads) 工具，如果你没有安装，可以点击 [Git](https://git-scm.com/downloads) 至官方网站进行下载安装。
 
-## 使用 Golang 连接 MatrixOne 服务
+## 使用 Golang 连接 MatrixOne Cloud 服务
 
-`Go-MySQL-Driver` 是一个用于 Go 语言的 MySQL 驱动程序，它实现了 Go 标准库中 database/sql 接口的方法，使得 Go 语言程序可以通过这个驱动程序连接和操作 MySQL 数据库。
+`Go-MySQL-Driver` 是一个用于 Go 语言的 MySQL 驱动程序，它实现了 Go 标准库中 `database/sql` 接口的方法，使得 Go 语言程序可以通过这个驱动程序连接和操作 MySQL 数据库。
 
 1. 安装 `Go-MySQL-Driver` 工具：
 
@@ -33,13 +34,13 @@ go version
     > go get -u github.com/go-sql-driver/mysql
     ```
 
-2. 使用 MySQL 客户端连接 MatrixOne。新建一个名称为 *test* 数据库：
+2. 使用 MySQL 客户端连接 MatrixOne Cloud。新建一个名称为 *test* 数据库：
 
     ```sql
     mysql> create database test;
     ```
 
-3. 创建一个纯文本文件 *golang_connect_matrixone.go* 并将代码写入文件：
+3. 创建一个纯文本文件 *golang_connect_matrixonecloud.go* 并将代码写入文件：
 
     ```go
     package main
@@ -47,82 +48,103 @@ go version
     import (
         "database/sql"
         "fmt"
+        "net/url"
+        "strconv"
+
         _ "github.com/go-sql-driver/mysql"
     )
 
     func main() {
-        //"username:password@[protocol](address:port)/database"
-        db, _ := sql.Open("mysql", "root:111@tcp(127.0.0.1:6001)/test") // Set database connection
-        defer db.Close()                                            //Close DB
-        err := db.Ping()                                            //Connect to DB
+        username := "tenant:user:role" // modify this
+        host := "host_ip_address"      // modify this
+        password := "your_password"    // modify this
+        port := 6001
+        database := "test"
+        encodedUsername := url.QueryEscape(username)
+        dsn := encodedUsername + ":" + password + "@tcp(" + host + ":" + strconv.Itoa(port) + ")/" + database
+        db, _ := sql.Open("mysql", dsn) // Set database connection
+        defer db.Close()                //Close DB
+        err := db.Ping()                //Connect to DB
         if err != nil {
-            fmt.Println("Database Connection Failed")               //Connection failed
+            fmt.Println("Database Connection Failed") //Connection failed
             return
         } else {
-            fmt.Println("Database Connection Succeed")              //Connection succeed
+            fmt.Println("Database Connection Succeed") //Connection succeed
         }
     }
+
     ```
 
 4. 打开一个终端，在终端内执行下面的命令：
 
     ```
-    > go run golang_connect_matrixone.go
+    > go run golang_connect_matrixonecloud.go
     Database Connection Succeed
     ```
 
-## 使用 Gorm 连接 MatrixOne 服务
+## 使用 Gorm 连接 MatrixOne Cloud 服务
 
 ```gorm``` 是一个基于 golang 的一个神奇的全功能 ORM 库，我们将使用 ```gorm.io/gorm``` 和 ```gorm.io/driver/mysql``` 这两个库来让 Go 连接到 MYSQL 数据库。
 
 1. 安装 ```gorm.io/gorm``` 和 ```gorm.io/driver/mysql``` 库，使用 ```go get``` 命令安装：
 
-   ```
-   go get -u gorm.io/gorm
-   go get -u gorm.io/driver/mysql
-   ```
+    ```
+    go get -u gorm.io/gorm
+    go get -u gorm.io/driver/mysql
+    ```
 
-2. 使用 MySQL 客户端连接 MatrixOne。新建一个名称为 *test* 数据库：
+2. 使用 MySQL 客户端连接 MatrixOne Cloud。新建一个名称为 *test* 数据库：
 
     ```sql
     mysql> create database test;
     ```
 
-3. 创建一个文本文件 *golang_gorm_connect_matrixone.go* 并将代码写入文件：
+3. 创建一个文本文件 *golang_gorm_connect_matrixonecloud.go* 并将代码写入文件：
 
     ```go
     package main
+
     import (
-     "gorm.io/driver/mysql"
-     "gorm.io/gorm"
-     "fmt"
-      )
+        "fmt"
+        "net/url"
+        "strconv"
+
+        "gorm.io/driver/mysql"
+        "gorm.io/gorm"
+    )
+
     func getDBConn() *gorm.DB {
-     dsn := "root:111@tcp(127.0.0.1:6001)/test?charset=utf8mb4&parseTime=True&loc=Local" //MO
-     db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{
-     })
-     // get connection
-     if err != nil {
-      fmt.Println("Database Connection Failed") //Connection failed
-     } else {
-      fmt.Println("Database Connection Succeed") //Connection succeed
-     }
-     return db
+        username := "tenant:user:role" // modify this
+        host := "host_ip_address"      // modify this
+        password := "your_password"    // modify this
+        port := 6001
+        database := "test"
+        encodedUsername := url.QueryEscape(username)
+        dsn := encodedUsername + ":" + password + "@tcp(" + host + ":" + strconv.Itoa(port) + ")/" + database
+        db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+        // get connection
+        if err != nil {
+            fmt.Println("Database Connection Failed") //Connection failed
+        } else {
+            fmt.Println("Database Connection Succeed") //Connection succeed
         }
-    func main() {
-     getDBConn()
+        return db
     }
+    func main() {
+        getDBConn()
+    }
+
     ```
 
 4. 打开一个终端，在终端内执行下面的命令：
 
     ```
-    > go run golang_gorm_connect_matrixone.go
+    > go run golang_gorm_connect_matrixonecloud.go
     Database Connection Succeed
     ```
 
 ## 参考文档
 
-关于使用 Golang 通过 MatrixOne 构建一个简单的 CRUD 的示例，参见 [Golang 基础示例](../Tutorial/develop-golang-crud-demo.md)。
+关于使用 Golang 通过 MatrixOne Cloud 构建一个简单的 CRUD 的示例，参见 [Golang 基础示例](../Tutorial/develop-golang-crud-demo.md)。
 
-关于使用 Gorm 通过 MatrixOne 构建一个简单的 CRUD 的示例，参见 [Gorm 基础示例](../Tutorial/gorm-golang-crud-demo.md)。
+关于使用 Gorm 通过 MatrixOne Cloud 构建一个简单的 CRUD 的示例，参见 [Gorm 基础示例](../Tutorial/gorm-golang-crud-demo.md)。


### PR DESCRIPTION
由于MOC用户名中包含英文冒号`:`，而连接串中是以冒号为分隔符，导致用户名识别失败，不能连接，需要进行一些编码才可以顺利完成验证。

同时修改了golang 代码的缩进，以及更新了MO的名称MatrixOne -> MatrixOne Cloud