### PR TITLE
feat(navigation): added `mo-docs` link to the tabs of navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
 nav:
-  - MatrixOne-Cloud:
+  - MatrixOne Cloud:
     - 主页: README.md
     - 关于 MatrixOne Cloud:
       - MatrixOne Cloud 简介: MatrixOne-Cloud/Overview/matrixonecloud-introduction.md
@@ -441,3 +441,4 @@ nav:
         - MatrixOne Cloud 常见问题: MatrixOne-Cloud/FAQs/FAQ-Product.md
     - 技术支持: MatrixOne-Cloud/tech-support.md
     - 术语表: MatrixOne-Cloud/glossary.md
+  - MatrixOne: https://docs.matrixorigin.cn/latest/


### PR DESCRIPTION
- Modified the tab title `MatrixOne-Cloud` to `MatrixOne Cloud`.
- Added the link of MatrixOne docs to the navigation tabs.

<img width="580" alt="WeChatWorkScreenshot_f20779ee-0bdc-4b3e-b7ba-e731d485b542" src="https://github.com/matrixone-cloud/moc-docs/assets/86586270/16a21c45-a2a6-4909-902c-516cca73c5c2">
