### PR TITLE
[codex] Add June 2026 release notes

### DIFF
--- a/docs/MatrixOne-Intelligence/Release-Notes/2026.md
+++ b/docs/MatrixOne-Intelligence/Release-Notes/2026.md
@@ -1,5 +1,134 @@
 # **MatrixOne Intelligence 2026 发布报告**
 
+## 2026 年 06 月 02 日
+
+**功能**
+
+- 新增 Catalog 自定义算子体系
+
+Catalog 新增自定义算子能力，支持通过 API、CLI、Go SDK、Python SDK 等方式管理自定义算子，并接入权限控制、Python Worker 注册、沙箱执行和相关文档。用户可基于业务场景扩展数据处理能力，进一步提升工作流编排的灵活性。
+
+- Explore / RAG Agent Runtime 升级
+
+Explore 迁移并接入新的 RAG Agent Runtime，支持 Explore Agent、A2A Runtime、工具调用、证据引用、RAG 文件检索和 SQL 工具链，增强结构化数据与非结构化文件的联合问答能力。
+
+- newmoi 接入模型服务
+
+newmoi 新增模型服务集成能力，支持在 workflow 和 taas 等场景中调用统一模型服务，便于模型能力在不同业务链路中复用。
+
+- 新增音频转写工作流模板
+
+系统新增音频转写工作流模板，覆盖音频解析、转写、分段、索引构建与结果保存的完整流程，降低语音类数据处理和知识库构建成本。
+
+- 解析产物 ZIP 与预览能力增强
+
+解析结果的 artifact ZIP 输出、解析结果预览和解析产物展示能力得到增强，用户可更方便地查看、校验和下载文档解析结果。
+
+- 工作流模型服务流式错误标准化
+
+工作流调用模型服务时的 stream 错误格式完成统一，并补充前端聊天面板的国际化和展示逻辑，使流式调用异常更易识别和定位。
+
+- SQL 历史和 Operation Log 页面增强
+
+SQL 历史列表新增总览统计并统一页面布局体验。Operation Log 页面也对齐 Guide 列表页交互与布局，提升日志与历史记录页面的一致性。
+
+- 前端工程与本地质量控制增强
+
+moi-app、moi-account 已迁移到 matrixflow 前端工程体系，并新增 moi-frontend 本地 Git hooks，提升前端协作、构建和提交前质量控制能力。
+
+- 部署与接口能力补齐
+
+optools 新增 Whisper NIM 本地部署 compose 配置，便于音频转写能力本地部署。同时补齐 moi-backend `PATCH` 请求的 CORS preflight 支持，提升接口兼容性。
+
+**优化**
+
+- 解析工作流体验优化
+
+标准 RAG / Parser 模板支持更多解析配置项，增强文档解析、OCR、跨页表格、公式修复等场景的配置灵活性。
+
+- 知识索引链路优化
+
+优化 vector index、lineage asset、KB indexed files 与 workflow outputs 的关联一致性，降低索引构建、资产登记和文件过滤过程中的状态偏差。
+
+- Explore 回答质量优化
+
+加强 SQL schema 约束、RAG 文件范围控制、证据保留、语义预览和结果计算，提升多轮问答、混合来源检索和 SQL 生成的可靠性。
+
+- Agent Runtime 可观测性与上下文优化
+
+Explore Agent Runtime 保留工具调用 thinking、最终分析上下文和 resultset refs，增强模型推理链路的连续性和可解释性。
+
+- 前端交互一致性优化
+
+统一列表总览、SQL 历史、账号页、DataShare 发布弹窗、PDF 预览和查询历史刷新体验，使常用页面的操作反馈和布局更加一致。
+
+- 权限与契约覆盖增强
+
+补充非管理员、邀请用户、DataShare、Audit 等关键路径测试覆盖，降低权限和接口契约回归风险。
+
+- 升级与部署稳定性优化
+
+增强 auto-upgrade、Mowl runtime lease、Catalog 镜像构建、CI tag、IDC 镜像更新等发布基础设施稳定性，减少升级和部署过程中的阻塞风险。
+
+- 文档与测试补齐
+
+同步更新 WorkItem、Catalog API、SDK、Auto Upgrade、Parser 架构、Workflow 等文档，并补充多类集成测试，提升发布内容的可验证性。
+
+**错误修复**
+
+- 修复了 document parse v2 下 MinerU 后端路由解析错误的问题；
+- 修复了知识索引构建时 `volume_id` 类型与 WorkItem schema 不匹配导致输入校验失败的问题；
+- 修复了 catalog bundle 中解析结果和结构化抽取结果聚合输出异常的问题；
+- 修复了多文件解析后 Catalog Sink 输出未按文件拆分的问题；
+- 修复了标准 RAG / parser 模板参数未正确透传的问题；
+- 修复了邮件解析中过小图片污染解析结果的问题；
+- 修复了解析 MIME tag 在表格单元格中的包裹与展示问题；
+- 修复了工作流 page selector 输入缺少校验的问题；
+- 修复了 workflow 运行配置标题语言缓存导致的中英文展示异常问题；
+- 修复了 Go Worker 从 YAML 加载 extract batch token 配置失败的问题；
+- 修复了 parser office converter 后端配置复用问题；
+- 修复了 vector write 文档 ID 不稳定导致重复或覆盖异常的问题；
+- 修复了 multilevel vector index 生成重复 ID 的问题；
+- 修复了 vector overwrite 非幂等导致重复写入或状态不一致的问题；
+- 修复了 lineage asset identity 未复用导致资产重复登记的问题；
+- 修复了知识库文件列表未按 workflow 输出过滤的问题；
+- 修复了 Explore 多轮对话中选中文件范围丢失的问题；
+- 修复了 RAG 工具查询时数据库 scope 串扰的问题；
+- 修复了混合来源场景未强制文件检索的问题；
+- 修复了 RAG 表格证据在回答链路中丢失的问题；
+- 修复了 RAG chunk retrieval 关键词检索策略问题；
+- 修复了 Query SQL schema gate 不够严格导致错误 SQL 进入执行链路的问题；
+- 修复了 semantic preview、SQL case / else 重写和查询边界问题；
+- 修复了 broadcast scalar result computation 结果计算问题；
+- 修复了 ratio percent display 和 growth rates 展示错误的问题；
+- 修复了 SQL resultset refs 未暴露给模型的问题；
+- 修复了 greeting 场景被 mixed source gate 错误拦截的问题；
+- 修复了 compute postprocess contract 不稳定的问题；
+- 修复了最终回答阶段 analysis context 丢失的问题；
+- 修复了 Agent Runtime 中 Explore 工具调用 thinking 被丢弃的问题；
+- 修复了 catalog / database / table 标识符缺少校验的问题；
+- 修复了订阅库建表错误码和前端提示不一致的问题；
+- 修复了 Catalog 文件下载时重复追加后缀的问题；
+- 修复了邀请用户 Catalog 库表权限异常的问题；
+- 修复了非管理员查看模型后端配置失败和模型资源权限覆盖不足的问题；
+- 修复了账号详情展示名来源、展示顺序和用户自我改名问题；
+- 修复了 DataShare 发布后端错误未展示的问题；
+- 修复了表共享发布范围提示缺失或位置不合理的问题；
+- 修复了 Mowl 启动恢复、租约抢占和租约时序相关稳定性问题；
+- 修复了 UUID batch insert 在 MatrixOne 下解析失败的问题；
+- 修复了租户 auto-upgrade 失败后阻塞升级、分阶段幂等不足和半创建状态无法恢复的问题；
+- 修复了 catalog local upgrade lifecycle 配置问题；
+- 修复了表格格式使用非列键结构导致的结果解析问题；
+- 修复了 migrator 中已有账号合并和权限迁移问题；
+- 修复了 DataShare 与 Audit API 契约覆盖不足和 audit failed result enum 不一致的问题；
+- 修复了 PDF 预览使用非原生 viewer 导致的展示问题；
+- 修复了重复 apply 查询条件后历史列表不刷新的问题；
+- 临时隐藏 moi-app compute resources 菜单，避免不可用入口暴露；
+- 修复了列表 overview 交互不统一的问题；
+- 修复了非 `v` 前缀 tag 构建时 `refs/tags` 前缀剥离错误的问题；
+- 修复了 Catalog 镜像构建缺少 agent runtime 文件的问题；
+- 修复了 moi-frontend IDC 更新调度互相影响和通用镜像 workflow 复用问题。
+
 ## 2026 年 05 月 25 日
 
 **功能**


### PR DESCRIPTION
## Summary

- Add the 2026-06-02 MatrixOne Intelligence release note entry.
- Rewrite the internal release material into the public `功能 / 优化 / 错误修复` structure.
- Cover Catalog custom operators, Explore/RAG Agent Runtime, model service integration, parsing/indexing improvements, and related bug fixes.

## Validation

- `git diff --check upstream/main..HEAD -- docs/MatrixOne-Intelligence/Release-Notes/2026.md`
- `pnpm exec markdownlint-cli2 docs/MatrixOne-Intelligence/Release-Notes/2026.md`
- `python3 -m mkdocs build`
- Verified generated HTML contains the new 2026-06-02 entry in `site/MatrixOne-Intelligence/Release-Notes/2026/index.html`