### PR TITLE
[codex] Add June 8 2026 release notes

### DIFF
--- a/docs/MatrixOne-Intelligence/Release-Notes/2026.md
+++ b/docs/MatrixOne-Intelligence/Release-Notes/2026.md
@@ -1,5 +1,71 @@
 # **MatrixOne Intelligence 2026 发布报告**
 
+## 2026 年 06 月 08 日
+
+**功能**
+
+- Agent 前端模块迁移
+
+Agent 前端模块完成迁移，并补充 Agent 聊天页、通用组件、API 接入和 mock 数据，为后续智能体相关能力在 newmoi 中持续迭代打好基础。
+
+- 默认 Catalog 结构优化
+
+默认 Catalog 结构完成调整，优化系统目录、保留库、导入流程与前端展示链路，使 Catalog 默认组织方式更清晰，也更贴合数据导入和后续管理场景。
+
+**优化**
+
+- 后端 API 与契约测试覆盖增强
+
+同步补充每周 backend API 变更测试覆盖，并对齐 api-tester 与 backend contract，提升接口变更的可验证性和回归稳定性。
+
+- Workspace 访问拒绝链路优化
+
+补充 workspace denial contract 测试覆盖，并优化 workspace access denial 日志，使权限拒绝场景更容易定位和排查。
+
+- 任务与工作流状态刷新体验优化
+
+任务页自动刷新和工作流 active execution 状态自动刷新体验得到优化，减少用户手动刷新成本，使执行状态展示更及时。
+
+- Mowl 运行日志与错误信息优化
+
+优化 Mowl RegisterNode 日志和 mismatch 错误信息，提升运行时节点注册、状态同步和异常排查的可观测性。
+
+- 前端工程规范补齐
+
+新增跨模块依赖规则文档，明确前端模块间依赖边界，提升协作开发的一致性和工程可维护性。
+
+**错误修复**
+
+- 修复了 genai 测试 count 规则读取字段错误的问题；
+- 修复了 LibreOffice 转换未以 headless 模式运行的问题；
+- 修复了工作流任务详情不展示导入文件的问题；
+- 修复了已绑定 trigger 的 volume 仍可被选择的问题；
+- 修复了重复创建 volume 时前端错误处理不明确的问题；
+- 修复了 Explore resultset embedding 检索缺失的问题；
+- 修复了 OCR captions 未写入 RAG markdown 产物的问题；
+- 修复了 Catalog 表统计为 0 的问题；
+- 修复了多文件导入名称未从 task id 派生的问题；
+- 修复了 Office / PDF 转换链路，优先使用 LibreOffice；
+- 修复了多文件导入未使用聚合名称的问题；
+- 修复了答案渲染 source binding 问题；
+- 修复了 Explore 对 qwen tool-call streaming 输出的处理问题；
+- 修复了 reserved database 语义与前后端一致性问题；
+- 修复了 CV ingest 未保存源文件 ID 的问题；
+- 修复了知识库卡片 source type 计数展示问题；
+- 修复了从知识库入口创建 chat 的流程问题；
+- 修复了目录清理能力缺失的问题；
+- 修复了重复创建 volume 时 Catalog 前端未展示错误的问题；
+- 修复了 VLM 请求未路由到声明 backend 的问题；
+- 修复了 semantic checklist 执行稳定性问题；
+- 修复了 Mowl 通过 callback 更新工作流状态的问题；
+- 修复了 volume source files 分页问题；
+- 修复了 backend model probe 未强制要求 API key 的问题；
+- 修复了任务分配加载、rerun 按钮和拓扑图展示问题；
+- 修复了 Catalog role sync 陈旧数据问题；
+- 修复了 Catalog table existence check 判断错误的问题；
+- 修复了 rerun 未保留 runtime context 和 lineage 的问题；
+- 修复了 page_selector 归属问题，改由解析节点处理。
+
 ## 2026 年 06 月 02 日
 
 **功能**


### PR DESCRIPTION
## Summary

- Add the 2026-06-08 MatrixOne Intelligence release note entry.
- Rewrite the internal release list into the public `功能 / 优化 / 错误修复` structure.
- Cover Agent frontend migration, default Catalog structure updates, workflow refresh improvements, and related bug fixes.

## Validation

- `git diff --check -- docs/MatrixOne-Intelligence/Release-Notes/2026.md`
- `pnpm exec markdownlint-cli2 docs/MatrixOne-Intelligence/Release-Notes/2026.md`
- `python3 -m mkdocs build`
- Verified generated HTML contains the new 2026-06-08 entry in `site/MatrixOne-Intelligence/Release-Notes/2026/index.html`